### PR TITLE
sending over working delete task btn and more notes/code

### DIFF
--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import TableDisplay from './TableDisplay.jsx';
 import NavBar from './NavBar.jsx';
 import '../css/Home.scss';
@@ -12,24 +12,29 @@ const Home = () => {
   // a way to use query of getting user -- maybe considering useEffect for less re-rendering ? 
   const { data, isError, isLoading, isSuccess, error } = useGetProjectQuery();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (isSuccess) {
+      const userData = data;
+      const projects = {}
+      for (const project of userData) {
+        projects[project.projectName] = project;
+      }
+      const transformedData = {
+        projects,
+        currentProject: 'Hi',
+      };
+      dispatch(setState(transformedData));
+    }
+  }, [dispatch, isSuccess, data]);
+
   if (isLoading) {
     return <div>Loading...</div>;
   }
   if (isError) {
     return <div>Error: {error}</div>;
   }
-  if (isSuccess) {
-    const userData = data;
-    const projects = {}
-    for (const project of userData) {
-      projects[project.projectName] = project;
-    }
-    const transformedData = {
-      projects,
-      currentProject: '',
-    };
-    dispatch(setState(transformedData));
-  }
+
   return (
     <div className='homeMain'>
       <NavBar />

--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -22,7 +22,7 @@ const Home = () => {
       }
       const transformedData = {
         projects,
-        currentProject: 'Hi',
+        currentProject: '',
       };
       dispatch(setState(transformedData));
     }

--- a/client/components/TableTask.jsx
+++ b/client/components/TableTask.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { deleteTask, updateTask, moveTask } from '../slices/userSlice';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TaskButton from './TaskButton.jsx';
 import TextModal from './TextModal.jsx';
 import { useDeleteTaskMutation, useUpdateTaskMutation, useMoveTaskMutation } from '../utils/userApi.js';
@@ -10,6 +10,7 @@ const TableTask = ({ task, column, currentProject }) => {
   const [incomingData, setIncomingData] = useState('');
   const [toggleModal, setToggleModal] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  // const comment = useSelector((state) => state.user.projects[state.user.currentProject]?.columns[task]?.[0]?.taskComment);
   const [deleteTaskMutation] = useDeleteTaskMutation();
   const [updateTaskMutation] = useUpdateTaskMutation();
   const [moveTaskMutation] = useMoveTaskMutation();
@@ -35,6 +36,28 @@ const TableTask = ({ task, column, currentProject }) => {
     }
   };
 
+  /* create a task - comments
+   req.body: a json object with the following fields:
+   - projectId
+   - columnId
+   - taskName
+*/
+  // const handleAddComment = async (e) => {
+  //   e.preventDefault();
+  //   const body = {
+  //     projectId: currentProject._id,
+  //     columnId: column._id,
+  //     taskId: task._id,
+  //     taskComments: incomingData,
+  //   };
+  //   try {
+  //     const res = await 
+  //   } catch (error) {
+
+  //   }
+  // }
+
+
   //NEEDS FOCUS 
   const handleMoveTask = async (columnName, taskToMove, newColumn) => {
     // e.preventDefault();
@@ -59,29 +82,28 @@ const TableTask = ({ task, column, currentProject }) => {
    - columnId
    - taskId*/
 
-  //NEEDS THE ACCESS OF PARAMS 
   const handleDeleteClick = async () => {
     // e.preventDefault();
     const body = {
       taskId: task._id,
       columnId: column._id,
       projectId: currentProject._id,
-      taskName: task.taskName
     };
+
+    console.log('proj', body);
     try {
+      if (!currentProject._id || !column._id || !task._id) {
+        console.error('Invalid project, column, or task id');
+        return;
+      }
+
       const res = await deleteTaskMutation(body);
+      console.log('res', res);
       if (res.error) throw new Error(res.error.message);
-      dispatch(deleteTask(res.data));
+      dispatch(deleteTask({ columnId: column._id, taskId: task._id, projectId: currentProject._id }));
     } catch (error) {
-      console.log(error);
+      console.log('Error in handleDeleteClick: ', error);
     }
-
-    //getting back undefined: http://localhost:8080/api/project/task/undefined/undefined/undefined
-
-    // console.log('Deleting task:', task.taskName);
-    // console.log('Find column', column.columnName);
-    // dispatch(deleteTask(task.taskName, column.columnName));
-    // console.log('clicked');
   };
 
 
@@ -93,11 +115,6 @@ const TableTask = ({ task, column, currentProject }) => {
           onClick={() => handleDeleteClick(task.taskName, column.columnName)}
           text='Delete'
           idOverride='innerTaskButton' />
-        {/* <TaskButton
-          onClick={() => setToggleModal(!toggleModal)}
-          text='Edit'
-          idOverride='innerTaskButton'
-        /> */}
         <TaskButton
           onClick={(e) => handleInputChange(e)}
           text='Edit'

--- a/client/components/TaskTextModal.jsx
+++ b/client/components/TaskTextModal.jsx
@@ -3,16 +3,42 @@ import TextInput from './TextInput.jsx';
 import Button from './Button.jsx';
 import { useDispatch } from 'react-redux';
 import { createTask } from '../slices/userSlice.js';
+// import { useAddTaskMutation } from '../utils/userApi.js';
 
 //FOR ADD TASK ?
 
 const TaskTextModal = ({ columnName, placeholder, setIsOpen, title }) => {
   const dispatch = useDispatch();
+  // const [ addTaskMutation ] = useAddTaskMutation();
   const [task, setTask] = useState('');
   const onClick = (e) => {
     e.preventDefault();
     dispatch(createTask({ columnName, task }));
   };
+
+  // const TaskTextModal = ({ columnName, placeholder, setIsOpen, title }) => {
+  //   const dispatch = useDispatch();
+  //   const [addTaskMutation] = useAddTaskMutation();
+  //   const [task, setTask] = useState('');
+  //   const handleAddTaskClick = async (e) => {
+  //     e.preventDefault();
+  //     const body = {
+  //       taskName: task,
+  //       columnName,
+  //       // columnId: column._id
+  //     };
+  //     try {
+  //       if (!task) {
+  //         console.error('No task given');
+  //         return;
+  //       }
+  //       const res = await addTaskMutation(body);
+  //       dispatch(createTask({ taskName: res.data, columnName }));
+  //       setIsOpen(false);
+  //     } catch (error) {
+  //       console.log('Error in handleDeleteClick: ', error);
+  //     }
+  //   };
 
   return (
     <div id='modal' className='textModalVisible'>

--- a/client/slices/userSlice.js
+++ b/client/slices/userSlice.js
@@ -27,7 +27,7 @@ export const userSlice = createSlice({
         const { findColumnName, task } = action.payload;
         const currentProject = state.currentProject;
         console.log(task);
-        state.projects[currentProject].columns = state.projects[currentProject].columns.map(el => {
+        state.projects[currentProject].columns = state.projects[currentProject].columns.map((el) => {
           if (el.columnName === findColumnName) {
             el.tasks.push({ taskName: task, taskComments: [] });
           }
@@ -131,16 +131,13 @@ export const userSlice = createSlice({
     deleteTask: (state, action) => {
       try {
         console.log('deleteTask reducer triggered');
-        let outerIndx = 0;
-        const { findColumnName, taskToDelete } = action.payload;
+        // let outerIndx = 0;
+        const { taskId, columnId } = action.payload;
         const currentProject = state.currentProject;
 
         console.log('state', current(state.projects[currentProject].columns));
         const column = state.projects[currentProject].columns.find(
-          (col, indx) => {
-            col.columnName === findColumnName
-            outerIndx = indx;
-          }
+          (col) => (col._id === columnId)
         );
 
         //returning undefined but is selected in the DELETE method, why? 
@@ -149,16 +146,9 @@ export const userSlice = createSlice({
         if (column) {
           //find index of the task to delete
           const taskIndex = column.tasks.findIndex(
-            (task) => task.taskName === taskToDelete
+            (task) => task._id === taskId
           );
           console.log('Task index:', taskIndex);
-
-          //if the tasks exist, use that index to delete it from the arr using splice
-          // if (taskIndex !== -1) {
-          //   const spliced = column.tasks.toSpliced(taskIndex, 1);
-          //   const newColumn = { ...column, tasks: spliced };
-          //   state.projects[currentProject].columns[outerIndx] = newColumn;
-          // }
 
           if (taskIndex !== -1) {
             const spliced = column.tasks.slice();
@@ -167,12 +157,12 @@ export const userSlice = createSlice({
             console.log('Tasks after splice:', spliced);
 
             const newColumn = { ...column, tasks: spliced };
-            const newProjects = [...state.projects];
-            newProjects[currentProject].columns[outerIndx] = newColumn;
+            // const newProjects = [...state.projects];
+            state.projects[currentProject].columns[taskIndex] = newColumn;
 
-            console.log('New projects:', newProjects);
+            // console.log('New projects:', newProjects);
 
-            return { ...state, projects: newProjects };
+            // return { ...state, projects: newProjects };
           }
         }
         console.log('Task not found');

--- a/client/utils/userApi.js
+++ b/client/utils/userApi.js
@@ -31,6 +31,10 @@ export const userApi = createApi({
       query: (body) => ({ url: '/project/task', method: 'POST', body }),
       invalidatesTags: ['Projects'],
     }),
+    addComment: builder.mutation({
+      query: (body) => ({ url: '/project/task/comment', method: 'POST', body }),
+      invalidatesTags: ['Projects'],
+    }),
     // Body: { projectId, columnId, taskId, taskName, taskComments}
     moveTask: builder.mutation({
       query: (body) => ({ url: '/project/', method: 'PATCH', body }),
@@ -44,7 +48,7 @@ export const userApi = createApi({
       invalidatesTags: ['Projects'],
     }),
     deleteTask: builder.mutation({
-      query: (body, projectId, columnId, taskId) => ({ url: `/project/task/${projectId}/${columnId}/${taskId}`, method: 'DELETE', body }),
+      query: ({ projectId, columnId, taskId }) => ({ url: `/project/task/${projectId}/${columnId}/${taskId}`, method: 'DELETE', }),
       invalidatesTags: ['Projects'],
     }),
     deleteColumn: builder.mutation({
@@ -58,4 +62,4 @@ export const userApi = createApi({
   }),
 });
 
-export const { useGetProjectQuery, useSendUserCredsMutation, useSignupUserMutation, useAddProjectMutation, useAddColumnMutation, useAddTaskMutation, useMoveTaskMutation, useUpdateTaskMutation, useDeleteTaskMutation, useDeleteColumnMutation, useDeleteProjectMutation } = userApi;
+export const { useGetProjectQuery, useSendUserCredsMutation, useSignupUserMutation, useAddProjectMutation, useAddColumnMutation, useAddTaskMutation, useAddCommentMutation, useMoveTaskMutation, useUpdateTaskMutation, useDeleteTaskMutation, useDeleteColumnMutation, useDeleteProjectMutation } = userApi;


### PR DESCRIPTION
**Issue Type**

- [] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
- Sending over working delete task btn
- Added code for add task using mutation
- Added code for handle add comment
- Wrapped isSuccess in Home.jsx with useEffect

**Ticket Item**
TRELLO - Ash: handleDeleteClick 

**Previous behavior**
handleDeleteTask was not functioning based on passed in params because it did not recognize them previously.

**Expected behavior**
When clicked, the task will be removed from the user interface from selected project and column.

**Additional context**
Added useEffect to wrap isSuccess because browser had an issue with rendering Home component multiple times -- useEffect helps remove this browser error. Order of calling useEffect matters after the if conditionals. 

Also noticed that handleAddTask in TaskTextModal logic is not based on mutation query, so added that as well but not completely functional yet.